### PR TITLE
Single precision constant speedup

### DIFF
--- a/Source/SysPSP/MediaEnginePRX/Makefile
+++ b/Source/SysPSP/MediaEnginePRX/Makefile
@@ -2,7 +2,7 @@ TARGET = mediaengine
 OBJS = me_stub.o main.o
 
 INCDIR =
-CFLAGS = -O2 -G0 -Wall
+CFLAGS = -O3 -G0 -Wall -ffast-math -fsingle-precision-constant
 
 
 CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti


### PR DESCRIPTION
Every little helps at this point right? Simplifying any ME math may help especially to lessen memory traffic, since the ME's local memory isn't that great.