### PR TITLE
Fixing scrolling issue for large ROMs list

### DIFF
--- a/Source/SysPS2/UI/RomSelectorComponent.cpp
+++ b/Source/SysPS2/UI/RomSelectorComponent.cpp
@@ -801,7 +801,7 @@ void	IRomSelectorComponent::Update( float elapsed_time, const v2 & stick, u32 ol
 		float d( 1.0f - powf(0.993f, elapsed_time * 1000.0f) );
 
 		u32		total_height( mRomsList.size() * line_height );
-		s32		min_offset( TEXT_AREA_HEIGHT - total_height );
+		s32		min_offset( (TEXT_AREA_HEIGHT/2) - total_height );
 
 		s32	new_scroll_offset = mCurrentScrollOffset + s32(float(adjust_amount) * d);
 

--- a/Source/SysPSP/UI/RomSelectorComponent.cpp
+++ b/Source/SysPSP/UI/RomSelectorComponent.cpp
@@ -801,7 +801,7 @@ void	IRomSelectorComponent::Update( float elapsed_time, const v2 & stick, u32 ol
 		float d( 1.0f - powf(0.993f, elapsed_time * 1000.0f) );
 
 		u32		total_height( mRomsList.size() * line_height );
-		s32		min_offset( TEXT_AREA_HEIGHT - total_height );
+		s32		min_offset( (TEXT_AREA_HEIGHT/2) - total_height );
 
 		s32	new_scroll_offset = mCurrentScrollOffset + s32(float(adjust_amount) * d);
 


### PR DESCRIPTION
For a long ROMs list (more than 150), scrolling was not working correctly and was not possible to select desired ROM.

Signed-off-by: Carlos Bombonatti <carlos.bombonatti@gmail.com>